### PR TITLE
Update SET and SETEX execute methods to omit named keys

### DIFF
--- a/aiohttp_cache/backends.py
+++ b/aiohttp_cache/backends.py
@@ -125,12 +125,12 @@ class RedisCache(BaseCache):
         
         if _expires == 0:
             async with self._redis_pool.get() as redis:
-                await redis.execute('SET', name=self.key_prefix + key,
-                                    value=dump)
+                await redis.execute('SET', self.key_prefix + key,
+                                    dump)
         else:
             async with self._redis_pool.get() as redis:
-                await redis.execute('SETEX', key=self.key_prefix + key,
-                                    seconds=_expires, value=dump)
+                await redis.execute('SETEX', self.key_prefix + key,
+                                    _expires, dump)
     
     async def delete(self, key: str):
         async with self._redis_pool.get() as redis:


### PR DESCRIPTION
Thanks for this library!

I ran into a problems which lead me to install from head but once I did I still had issues with the set and setex methods. Looks like the parameters to execute aren't named. I removed the names and it worked afterwards. Not sure if it is some version difference in what I am using (aioredis==1.2.0) or something else.