### PR TITLE
Feature/add integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+CACHE_URL=redis://redis:6379/0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7 as base
+
+FROM base as install-deps
+WORKDIR /aiohttp-cache
+
+COPY ./requirements.txt .
+COPY ./requirements-test.txt .
+
+RUN pip install -r requirements.txt
+RUN pip install -r requirements-test.txt
+
+FROM install-deps as copy-src
+COPY . .

--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,9 @@ Source Code
 -----------
 
 The latest developer version is available in a github repository: https://github.com/cr0hn/aiohttp-cache
+
+Development Version
+-------------------
+
+1. cp .env.example .env
+2. docker-compose run tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+services:
+  tests:
+    environment:
+      CACHE_URL: ${CACHE_URL}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - &img_tag aiohttp-cache:latest
+    image: *img_tag
+    volumes:
+      - .:/aiohttp-cache
+    depends_on:
+      - redis
+    command: pytest
+
+  redis:
+    image: "redis:5.0.6"
+    ports:
+      - "63790:6379"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = --cov=aiohttp_cache --cov-branch --cov-report=term-missing:skip-covered --cov-fail-under=65 --no-cov-on-fail -p no:warnings --tb=native

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-aiohttp
+pytest-cov
+envparse

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Security',
     ],
-    tests_require=['pytest', 'pytest-aiohttp'],
+    tests_require=['pytest', 'pytest-aiohttp', 'pytest-cov'],
     cmdclass=dict(test=PyTest)
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+import yarl
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+from envparse import env
+
+from aiohttp_cache import setup_cache, cache, RedisConfig
+
+env.read_envfile("/aiohttp-cache/.env")
+
+PAYLOAD = {"hello": "aiohttp_cache"}
+WAIT_TIME = 2
+
+
+@cache()
+async def some_long_running_view(request: web.Request) -> web.Response:
+    await asyncio.sleep(WAIT_TIME)
+    payload = await request.json()
+    return web.json_response(payload)
+
+
+def build_application(cache_type="memory"):
+    app = web.Application()
+    if cache_type == "memory":
+        setup_cache(app)
+    elif cache_type == "redis":
+        url = yarl.URL(env.str("CACHE_URL"))
+        redis_config = RedisConfig(db=int(url.path[1:]), host=url.host, port=url.port)
+        setup_cache(app, cache_type=cache_type, backend_config=redis_config)
+    else:
+        raise ValueError("cache_type should be `memory` or `redis`")
+    app.router.add_post("/", some_long_running_view)
+    return app
+
+
+@pytest.fixture
+def client_memory_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(build_application(cache_type="memory"))
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_
+
+
+@pytest.fixture
+def client_redis_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(build_application(cache_type="redis"))
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,27 @@
+import time
+
+from tests.conftest import PAYLOAD
+
+
+async def test_memory_cache(client_memory_cache):
+    # check if cache really exists
+    assert client_memory_cache.app["cache"]
+
+    # check if the response is coming from cache (quick)
+    tic = time.monotonic()
+    resp = await client_memory_cache.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    assert await resp.json() == PAYLOAD
+    assert (time.monotonic() - tic) < 0.1
+
+
+async def test_redis_cache(client_redis_cache):
+    # check if cache really exists
+    assert client_redis_cache.app["cache"]
+
+    # check if the response is coming from cache (quick)
+    tic = time.monotonic()
+    resp = await client_redis_cache.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    assert await resp.json() == PAYLOAD
+    assert (time.monotonic() - tic) < 0.1


### PR DESCRIPTION
Idea of testing is simple. Create a long running view and then test it with cache and check if it become quick.

Things done:


1. Add aiohttp TestClients which supports memory and redis cache

- Adding two fixtures which has the cache enabled with redis and
memory backends
- Introduce a long running view which we'll be caching
- Submit one request with PAYLOAD body to cache it

2. Add docker-compose, coverage and a section in README

- introduced a way to test a redis backend with a help of docker-compose

In this way we are really testing the redis backend with a real database.
docker-compose has a `tests` service which depends on `redis` service.

- adding coverage report, which with two backends tests already achieving
65% of coverage

- update README to describe how to setup the dev-env

ref #10 