### PR TITLE
Feature/add costum key pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+CACHE_URL=redis://redis:6379/0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7 as base
+
+FROM base as install-deps
+WORKDIR /aiohttp-cache
+
+COPY ./requirements.txt .
+COPY ./requirements-test.txt .
+
+RUN pip install -r requirements.txt
+RUN pip install -r requirements-test.txt
+
+FROM install-deps as copy-src
+COPY . .

--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,9 @@ Source Code
 -----------
 
 The latest developer version is available in a github repository: https://github.com/cr0hn/aiohttp-cache
+
+Development Version
+-------------------
+
+1. cp .env.example .env
+2. docker-compose run tests

--- a/aiohttp_cache/backends.py
+++ b/aiohttp_cache/backends.py
@@ -1,8 +1,9 @@
-import enum
-import time
-import pickle
 import asyncio
+import enum
+import pickle
+import time
 import warnings
+from _sha256 import sha256
 from typing import Tuple
 
 import aiohttp.web
@@ -10,7 +11,9 @@ import aiohttp.web
 try:
     import aioredis
 except ImportError:
-    warnings.showwarning("aioredis library not found. Redis cache backend not available")
+    warnings.showwarning(
+        "aioredis library not found. Redis cache backend not available"
+    )
 
 
 class AvailableKeys(enum.Enum):
@@ -23,38 +26,40 @@ class AvailableKeys(enum.Enum):
 
 
 DEFAULT_KEY_PATTERN = (
-                AvailableKeys.method,
-                AvailableKeys.host,
-                AvailableKeys.path,
-                AvailableKeys.postdata,
-                AvailableKeys.ctype,
-            )
+    AvailableKeys.method,
+    AvailableKeys.host,
+    AvailableKeys.path,
+    AvailableKeys.postdata,
+    AvailableKeys.ctype,
+)
 
 
 class BaseCache(object):
-    
     def __init__(
-            self, expiration: int = 300, 
-            key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN
+        self,
+        expiration: int = 300,
+        key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN,
+        encrypt_key=True,
     ):
+        self.encrypt_key = encrypt_key
         self.expiration = expiration
         self.key_pattern = key_pattern
 
     async def get(self, key: str) -> object:
         raise NotImplementedError()
-    
+
     async def delete(self, key: str):
         raise NotImplementedError()
-    
+
     async def has(self, key: str) -> bool:
         raise NotImplementedError()
-    
+
     async def clear(self):
         raise NotImplementedError()
-    
+
     async def set(self, key: str, value: dict, expires: int = 3000):
         raise NotImplementedError()
-    
+
     async def make_key(self, request: aiohttp.web.Request) -> str:
         K = AvailableKeys
         known_keys = {
@@ -63,19 +68,21 @@ class BaseCache(object):
             K.host: request.url.host,
             K.postdata: "".join(await request.post()),
             K.ctype: request.content_type,
-            K.json: await request.text()
+            K.json: await request.text(),
         }
         key = "#".join(known_keys[key] for key in self.key_pattern)
 
+        if self.encrypt_key:
+            key = sha256(key.encode()).hexdigest()
+
         return key
-    
+
     def _calculate_expires(self, expires: int) -> int:
         return self.expiration if expires is None or expires < 0 else expires
 
 
 class _Config:
-    def __init__(self,
-                 expiration: int = 300):
+    def __init__(self, expiration: int = 300):
         self.expiration = expiration
 
 
@@ -83,60 +90,64 @@ class _Config:
 # REDIS BACKEND
 # --------------------------------------------------------------------------
 class RedisConfig(_Config):
-    
-    def __init__(self,
-                 host: str = 'localhost',
-                 port: int = 6379,
-                 db: int = 0,
-                 password: str = None,
-                 key_prefix: str = None,
-                 ):
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
+        password: str = None,
+        key_prefix: str = None,
+    ):
         self.host = host
         self.port = port
         self.password = password
         self.db = db
-        self.key_prefix = key_prefix or ''
-        
+        self.key_prefix = key_prefix or ""
+
         super(RedisConfig, self).__init__()
 
 
 class RedisCache(BaseCache):
-    
-    def __init__(self,
-                 config: RedisConfig,
-                 *,
-                 loop: asyncio.BaseEventLoop = None,
-                 expiration: int = 300,
-                 key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN
-                 ):
+    def __init__(
+        self,
+        config: RedisConfig,
+        *,
+        loop: asyncio.BaseEventLoop = None,
+        expiration: int = 300,
+        key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN,
+        encrypt_key=True,
+    ):
         """
-        
+
         :param loop:
         :type loop:
         """
         BaseCache.__init__(self, config.expiration)
         _loop = loop or asyncio.get_event_loop()
 
-        self._redis_pool = _loop.run_until_complete(aioredis.create_pool((config.host, config.port),
-                                                                         db=config.db,
-                                                                         password=config.password))
+        self._redis_pool = _loop.run_until_complete(
+            aioredis.create_pool(
+                (config.host, config.port), db=config.db, password=config.password
+            )
+        )
         self.key_prefix = config.key_prefix
-        super().__init__(expiration=expiration, key_pattern=key_pattern)
+        super().__init__(
+            expiration=expiration, key_pattern=key_pattern, encrypt_key=encrypt_key
+        )
 
-    
     def dump_object(self, value: dict) -> bytes:
         t = type(value)
-        if t in (int, ):
-            return str(value).encode('ascii')
-        return b'!' + pickle.dumps(value)
-    
+        if t in (int,):
+            return str(value).encode("ascii")
+        return b"!" + pickle.dumps(value)
+
     def load_object(self, value):
         """The reversal of :meth:`dump_object`.  This might be called with
         None.
         """
         if value is None:
             return None
-        if value.startswith(b'!'):
+        if value.startswith(b"!"):
             try:
                 return pickle.loads(value[1:])
             except pickle.PickleError:
@@ -146,41 +157,39 @@ class RedisCache(BaseCache):
         except ValueError:
             # before 0.8 we did not have serialization.  Still support that.
             return value
-    
+
     async def get(self, key: str):
         async with self._redis_pool.get() as redis:
-            redis_value = await redis.execute('GET', self.key_prefix + key)
-            
+            redis_value = await redis.execute("GET", self.key_prefix + key)
+
             return self.load_object(redis_value)
-    
+
     async def set(self, key: str, value: dict, expires: int = 3000):
         dump = self.dump_object(value)
-        
+
         _expires = self._calculate_expires(expires)
-        
+
         if _expires == 0:
             async with self._redis_pool.get() as redis:
-                await redis.execute('SET', self.key_prefix + key,
-                                    dump)
+                await redis.execute("SET", self.key_prefix + key, dump)
         else:
             async with self._redis_pool.get() as redis:
-                await redis.execute('SETEX', self.key_prefix + key,
-                                    _expires, dump)
-    
+                await redis.execute("SETEX", self.key_prefix + key, _expires, dump)
+
     async def delete(self, key: str):
         async with self._redis_pool.get() as redis:
-            await redis.execute('DEL', self.key_prefix + key)
-    
+            await redis.execute("DEL", self.key_prefix + key)
+
     async def has(self, key: str) -> bool:
         async with self._redis_pool.get() as redis:
-            return await redis.execute('EXISTS', self.key_prefix + key)
-    
+            return await redis.execute("EXISTS", self.key_prefix + key)
+
     async def clear(self):
         async with self._redis_pool.get() as redis:
             if self.key_prefix:
-                keys = await redis.execute('KEYS', self.key_prefix + '*')
+                keys = await redis.execute("KEYS", self.key_prefix + "*")
                 if keys:
-                    await redis.execute('DEL', *keys)
+                    await redis.execute("DEL", *keys)
             else:
                 await redis.flushdb()
 
@@ -189,62 +198,71 @@ class RedisCache(BaseCache):
 # MEMORY BACKEND
 # --------------------------------------------------------------------------
 class MemoryCache(BaseCache):
-
-    def __init__(self,
-                 *,
-                 expiration=300,
-                 key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN
-                 ):
-        super().__init__(expiration=expiration, key_pattern=key_pattern)
+    def __init__(
+        self,
+        *,
+        expiration=300,
+        key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN,
+        encrypt_key=True,
+    ):
+        super().__init__(
+            expiration=expiration, key_pattern=key_pattern, encrypt_key=encrypt_key
+        )
 
         #
         # Cache format:
         # (cached object, expire date)
         #
         self._cache = {}
-    
+
     async def get(self, key: str):
         # Update the keys
         self._update_expiration_key(key)
-        
+
         try:
             cached = self._cache[key]
-            
+
             return cached[0]
         except KeyError:
             return None
-    
+
     async def set(self, key: str, value: dict, expires: int = 3000):
         _expires = self._calculate_expires(expires)
-        
+
         self._cache[key] = (value, int(time.time()) + _expires)
-    
+
     async def has(self, key: str):
         # Update the keys
         self._update_expiration_key(key)
-        
+
         return key in self._cache
-    
+
     async def delete(self, key: str):
         # Update the keys
         self._update_expiration_key(key)
-        
+
         try:
             del self._cache[key]
         except KeyError:
             pass
-    
+
     async def clear(self):
         self._cache = {}
-    
+
     def _update_expiration_key(self, key: str):
         try:
             expiration = self._cache[key][1]
-            
+
             if expiration < int(time.time()):
                 del self._cache[key]
         except KeyError:
             pass
 
 
-__all__ = ("MemoryCache", "RedisCache", "RedisConfig", "AvailableKeys", "DEFAULT_KEY_PATTERN")
+__all__ = (
+    "MemoryCache",
+    "RedisCache",
+    "RedisConfig",
+    "AvailableKeys",
+    "DEFAULT_KEY_PATTERN",
+)

--- a/aiohttp_cache/setup.py
+++ b/aiohttp_cache/setup.py
@@ -2,24 +2,27 @@ import logging
 from typing import Tuple
 
 from aiohttp import web
+from envparse import env
 
 from .backends import *
 from .exceptions import *
 from .middleware import *
 
 log = logging.getLogger("aiohttp")
+env.read_envfile(".env")
 
 
 def setup_cache(app: web.Application,
                 cache_type: str = "memory",
                 key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN,
+                encrypt_key=True,
                 backend_config=None,
 ):
     app.middlewares.append(cache_middleware)
 
     _cache_backend = None
     if cache_type.lower() == "memory":
-        _cache_backend = MemoryCache(key_pattern=key_pattern)
+        _cache_backend = MemoryCache(key_pattern=key_pattern, encrypt_key=encrypt_key)
 
         log.debug("Selected cache: {}".format(cache_type.upper()))
 
@@ -28,7 +31,9 @@ def setup_cache(app: web.Application,
 
         assert isinstance(_redis_config, RedisConfig), \
             "Config must be a RedisConfig object. Got: '{}'".format(type(_redis_config))
-        _cache_backend = RedisCache(config=_redis_config, key_pattern=key_pattern)
+        _cache_backend = RedisCache(
+            config=_redis_config, key_pattern=key_pattern, encrypt_key=encrypt_key
+        )
 
         log.debug("Selected cache: {}".format(cache_type.upper()))
     else:

--- a/aiohttp_cache/setup.py
+++ b/aiohttp_cache/setup.py
@@ -1,36 +1,39 @@
 import logging
+from typing import Tuple
 
 from aiohttp import web
 
 from .backends import *
-from .middleware import *
 from .exceptions import *
+from .middleware import *
 
 log = logging.getLogger("aiohttp")
 
 
 def setup_cache(app: web.Application,
                 cache_type: str = "memory",
-                backend_config=None):
+                key_pattern: Tuple[AvailableKeys] = DEFAULT_KEY_PATTERN,
+                backend_config=None,
+):
     app.middlewares.append(cache_middleware)
-    
+
     _cache_backend = None
     if cache_type.lower() == "memory":
-        _cache_backend = MemoryCache()
-        
+        _cache_backend = MemoryCache(key_pattern=key_pattern)
+
         log.debug("Selected cache: {}".format(cache_type.upper()))
-        
+
     elif cache_type.lower() == "redis":
         _redis_config = backend_config or RedisConfig()
-        
+
         assert isinstance(_redis_config, RedisConfig), \
             "Config must be a RedisConfig object. Got: '{}'".format(type(_redis_config))
-        _cache_backend = RedisCache(config=_redis_config)
-        
+        _cache_backend = RedisCache(config=_redis_config, key_pattern=key_pattern)
+
         log.debug("Selected cache: {}".format(cache_type.upper()))
     else:
         raise HTTPCache("Invalid cache type selected")
-    
+
     app["cache"] = _cache_backend
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+services:
+  tests:
+    environment:
+      CACHE_URL: ${CACHE_URL}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - &img_tag aiohttp-cache:latest
+    image: *img_tag
+    volumes:
+      - .:/aiohttp-cache
+    depends_on:
+      - redis
+    command: pytest
+
+  redis:
+    image: "redis:5.0.6"
+    ports:
+      - "63790:6379"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = --cov=aiohttp_cache --cov-branch --cov-report=term-missing:skip-covered --cov-fail-under=65 --no-cov-on-fail -p no:warnings --tb=native

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-aiohttp
+pytest-cov
+envparse

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Security',
     ],
-    tests_require=['pytest', 'pytest-aiohttp'],
+    tests_require=['pytest', 'pytest-aiohttp', 'pytest-cov'],
     cmdclass=dict(test=PyTest)
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,12 @@ def build_application(
     cache_type="memory",
     key_pattern=DEFAULT_KEY_PATTERN,
     loop: asyncio.AbstractEventLoop = None,
+    encrypt_key=True,
 ) -> web.Application:
     app = web.Application()
     if cache_type == "memory":
         setup_cache(
-            app, key_pattern=key_pattern,
+            app, key_pattern=key_pattern, encrypt_key=encrypt_key,
         )
     elif cache_type == "redis":
         url = yarl.URL(env.str("CACHE_URL"))
@@ -40,6 +41,7 @@ def build_application(
             cache_type=cache_type,
             backend_config=redis_config,
             key_pattern=key_pattern,
+            encrypt_key=encrypt_key,
         )
     else:
         raise ValueError("cache_type should be `memory` or `redis`")
@@ -80,7 +82,7 @@ def client_memory_cache_another_key(
     client_: TestClient = loop.run_until_complete(
         aiohttp_client(
             build_application(
-                cache_type="memory", key_pattern=(K.method, K.path, K.json)
+                cache_type="memory", key_pattern=(K.method, K.path, K.json), encrypt_key=False,
             )
         )
     )
@@ -99,7 +101,7 @@ def client_redis_cache_another_key(
     client_: TestClient = loop.run_until_complete(
         aiohttp_client(
             build_application(
-                cache_type="redis", key_pattern=(K.method, K.path, K.json)
+                cache_type="redis", key_pattern=(K.method, K.path, K.json), encrypt_key=False,
             )
         )
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+import yarl
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+from envparse import env
+
+from aiohttp_cache import setup_cache, cache, RedisConfig
+
+env.read_envfile("/aiohttp-cache/.env")
+
+PAYLOAD = {"hello": "aiohttp_cache"}
+WAIT_TIME = 2
+
+
+@cache()
+async def some_long_running_view(request: web.Request) -> web.Response:
+    await asyncio.sleep(WAIT_TIME)
+    payload = await request.json()
+    return web.json_response(payload)
+
+
+def build_application(cache_type="memory"):
+    app = web.Application()
+    if cache_type == "memory":
+        setup_cache(app)
+    elif cache_type == "redis":
+        url = yarl.URL(env.str("CACHE_URL"))
+        redis_config = RedisConfig(db=int(url.path[1:]), host=url.host, port=url.port)
+        setup_cache(app, cache_type=cache_type, backend_config=redis_config)
+    else:
+        raise ValueError("cache_type should be `memory` or `redis`")
+    app.router.add_post("/", some_long_running_view)
+    return app
+
+
+@pytest.fixture
+def client_memory_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(build_application(cache_type="memory"))
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_
+
+
+@pytest.fixture
+def client_redis_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(build_application(cache_type="redis"))
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient
 from envparse import env
 
-from aiohttp_cache import setup_cache, cache, RedisConfig
+from aiohttp_cache import setup_cache, cache, RedisConfig, DEFAULT_KEY_PATTERN
+from aiohttp_cache.backends import AvailableKeys as K
 
 env.read_envfile("/aiohttp-cache/.env")
 
@@ -21,14 +22,25 @@ async def some_long_running_view(request: web.Request) -> web.Response:
     return web.json_response(payload)
 
 
-def build_application(cache_type="memory"):
+def build_application(
+    cache_type="memory",
+    key_pattern=DEFAULT_KEY_PATTERN,
+    loop: asyncio.AbstractEventLoop = None,
+) -> web.Application:
     app = web.Application()
     if cache_type == "memory":
-        setup_cache(app)
+        setup_cache(
+            app, key_pattern=key_pattern,
+        )
     elif cache_type == "redis":
         url = yarl.URL(env.str("CACHE_URL"))
         redis_config = RedisConfig(db=int(url.path[1:]), host=url.host, port=url.port)
-        setup_cache(app, cache_type=cache_type, backend_config=redis_config)
+        setup_cache(
+            app,
+            cache_type=cache_type,
+            backend_config=redis_config,
+            key_pattern=key_pattern,
+        )
     else:
         raise ValueError("cache_type should be `memory` or `redis`")
     app.router.add_post("/", some_long_running_view)
@@ -52,6 +64,44 @@ def client_memory_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> Test
 def client_redis_cache(loop: asyncio.AbstractEventLoop, aiohttp_client) -> TestClient:
     client_: TestClient = loop.run_until_complete(
         aiohttp_client(build_application(cache_type="redis"))
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_
+
+
+@pytest.fixture
+def client_memory_cache_another_key(
+    loop: asyncio.AbstractEventLoop, aiohttp_client
+) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(
+            build_application(
+                cache_type="memory", key_pattern=(K.method, K.path, K.json)
+            )
+        )
+    )
+
+    # doing a first request to load it to the cache
+    response = loop.run_until_complete(client_.post("/", json=PAYLOAD))
+
+    assert response.status == 200
+    return client_
+
+
+@pytest.fixture
+def client_redis_cache_another_key(
+    loop: asyncio.AbstractEventLoop, aiohttp_client
+) -> TestClient:
+    client_: TestClient = loop.run_until_complete(
+        aiohttp_client(
+            build_application(
+                cache_type="redis", key_pattern=(K.method, K.path, K.json)
+            )
+        )
     )
 
     # doing a first request to load it to the cache

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,3 +25,27 @@ async def test_redis_cache(client_redis_cache):
     assert resp.status == 200
     assert await resp.json() == PAYLOAD
     assert (time.monotonic() - tic) < 0.1
+
+
+async def test_key_patterns_memory(client_memory_cache_another_key):
+    resp = await client_memory_cache_another_key.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    cache = client_memory_cache_another_key.app["cache"]
+    res = await cache.get(r'POST#/#{"hello": "aiohttp_cache"}')
+    assert res == {
+        "status": 200,
+        "headers": {"Content-Type": "application/json; charset=utf-8"},
+        "body": b'{"hello": "aiohttp_cache"}',
+    }
+
+
+async def test_key_patterns_redis(client_redis_cache_another_key):
+    resp = await client_redis_cache_another_key.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    cache = client_redis_cache_another_key.app["cache"]
+    res = await cache.get(r'POST#/#{"hello": "aiohttp_cache"}')
+    assert res == {
+        "status": 200,
+        "headers": {"Content-Type": "application/json; charset=utf-8"},
+        "body": b'{"hello": "aiohttp_cache"}',
+    }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,27 @@
+import time
+
+from tests.conftest import PAYLOAD
+
+
+async def test_memory_cache(client_memory_cache):
+    # check if cache really exists
+    assert client_memory_cache.app["cache"]
+
+    # check if the response is coming from cache (quick)
+    tic = time.monotonic()
+    resp = await client_memory_cache.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    assert await resp.json() == PAYLOAD
+    assert (time.monotonic() - tic) < 0.1
+
+
+async def test_redis_cache(client_redis_cache):
+    # check if cache really exists
+    assert client_redis_cache.app["cache"]
+
+    # check if the response is coming from cache (quick)
+    tic = time.monotonic()
+    resp = await client_redis_cache.post("/", json=PAYLOAD)
+    assert resp.status == 200
+    assert await resp.json() == PAYLOAD
+    assert (time.monotonic() - tic) < 0.1


### PR DESCRIPTION
Introduces a possibility to customize the key stored in the cache backend in order to give the developers control over the key creation.

Now the setup function has the following signature:
```python
def setup_cache(app: web.Application,
                cache_type: str = "memory",
                key_pattern: Tuple[AvailableKeys] = (
                     AvailableKeys.method,
                     AvailableKeys.host,
                     AvailableKeys.path,
                    AvailableKeys.postdata,
                    AvailableKeys.ctype,
                ),
                encrypt_key=True,
                backend_config=None,
):
```

- [x] Before merging this one https://github.com/cr0hn/aiohttp-cache/pull/11 should be merged.

resolves #10 