### PR TITLE
Improve/smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM python:3.8 as base
+FROM python:3.8-alpine as base
 
 FROM base as install-poetry
-RUN pip install poetry
+RUN apk add --no-cache gcc musl-dev
+RUN wget -O - https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+ENV PATH="/root/.local/bin:/root/.poetry/bin:${PATH}"
 
 FROM install-poetry as install-deps
 WORKDIR /aiohttp-cache
 COPY ./pyproject.toml .
 COPY ./poetry.lock .
+
 RUN poetry install
 
 FROM install-deps as copy-src

--- a/aiohttp_cache/backends.py
+++ b/aiohttp_cache/backends.py
@@ -2,18 +2,11 @@ import asyncio
 import enum
 import pickle
 import time
-import warnings
 from _sha256 import sha256  # noqa
 from typing import Tuple  # noqa
 
 import aiohttp.web
-
-try:
-    import aioredis
-except ImportError:
-    warnings.showwarning(
-        "aioredis library not found. Redis cache backend not available"
-    )
+import aioredis
 
 
 class AvailableKeys(enum.Enum):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
   redis:
     image: "redis:5.0.7"
     ports:
-      - "63790:6379"
+      - "6379:6379"


### PR DESCRIPTION
Use python alpine image

- Size reduce from 1GB -> 300 Mb > faster builds

Adjust redis ports mapping for local env comfort

Now you can do:
- docker-compose up redis
- poetry run pytest
