### PR TITLE
Release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,41 @@ app.router.add_post("/", some_long_running_view)
 web.run_app(app)
 ```
 
+## Parametrize the cache decorator
+
+```python
+import asyncio
+
+from aiohttp import web
+
+from aiohttp_cache import (  # noqa
+    setup_cache,
+    cache,
+)
+
+PAYLOAD = {"hello": "aiohttp_cache"}
+WAIT_TIME = 2
+
+
+@cache(
+    expires=1 * 24 * 3600,  # in seconds
+    unless=False,  # anything what returns a bool. if True - skips cache
+)
+async def some_long_running_view(
+    request: web.Request,
+) -> web.Response:
+    await asyncio.sleep(WAIT_TIME)
+    payload = await request.json()
+    return web.json_response(payload)
+
+
+app = web.Application()
+setup_cache(app)
+app.router.add_post("/", some_long_running_view)
+
+web.run_app(app)
+```
+
 # License
 
 This project is released under BSD license. Feel free


### PR DESCRIPTION
# 2.1.0 (20 Jul 2020)

## Fixes
- using sha256 from hashlib see
(https://github.com/cr0hn/aiohttp-cache/pull/26)

## Features
- Supports python 3.6, 3.7 and 3.8
- Monthly maintenance update
