### PR TITLE
Add py.typed to expose types to applications using this library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ classifiers = [
 readme = "README.md"
 repository = "https://github.com/cr0hn/aiohttp-cache"
 license = "BSD"
+include = [ "py.typed",]
 
 [tool.poetry.dependencies]
 python = "^3.6.8"


### PR DESCRIPTION
Hello,

I would like  to add `py.typed` to the project to enable type checking when installed in other applications. I've tested this with one application that is using `cache` and it looks good